### PR TITLE
Explicitly use parameter binding to prevent generating mangled FQN pr…

### DIFF
--- a/src/Models/Projection.php
+++ b/src/Models/Projection.php
@@ -87,7 +87,7 @@ class Projection extends Model
     {
         $this->projectionName = $projectorName;
 
-        return $query->where('projection_name', $projectorName);
+        return $query->whereRaw('projection_name = ?', [$projectorName]);
     }
 
     /**

--- a/src/Models/Scopes/ProjectionScope.php
+++ b/src/Models/Scopes/ProjectionScope.php
@@ -15,7 +15,7 @@ class ProjectionScope implements Scope
     public function apply(Builder $builder, Model $model): void
     {
         if (! $this->isAbstractProjection($model)) {
-            $builder->where('projection_name', $model::class);
+            $builder->whereRaw('projection_name = ?', [$model::class]);
         }
     }
 

--- a/src/Models/Traits/Projectable.php
+++ b/src/Models/Traits/Projectable.php
@@ -52,7 +52,7 @@ trait Projectable
         $query = $this->morphToMany(Projection::class, 'projectable', 'time_series_projectables');
 
         if (isset($projectionName)) {
-            $query->where('projection_name', $projectionName);
+            $query->whereRaw('projection_name = ?', [$projectionName]);
         }
 
         if (isset($periods) && is_string($periods)) {

--- a/src/Projector.php
+++ b/src/Projector.php
@@ -87,12 +87,13 @@ class Projector
      */
     private function findGlobalProjection(): Projection|null
     {
-        return Projection::firstWhere([
-            ['projection_name', $this->projectionName],
-            ['key', $this->hasKey() ? $this->key() : null],
-            ['period', '*'],
-            ['start_date', null],
-        ]);
+        return Projection::whereRaw('projection_name = ?', [$this->projectionName])
+             ->where([
+                 ['key', $this->hasKey() ? $this->key() : null],
+                 ['period', '*'],
+                 ['start_date', null],
+             ])
+             ->first();
     }
 
     /**
@@ -100,12 +101,14 @@ class Projector
      */
     private function findProjection(string $period): Projection|null
     {
-        return Projection::firstWhere([
-            ['projection_name', $this->projectionName],
-            ['key', $this->hasKey() ? $this->key() : null],
-            ['period', $period],
-            ['start_date', app(TimeSeries::class)->resolveFloorDate($this->projectedModel->created_at, $period)],
-        ]);
+        return Projection::whereRaw('projection_name = ?', [$this->projectionName])
+             ->where([
+                 ['key', $this->hasKey() ? $this->key() : null],
+                 ['period', $period],
+                 ['start_date', app(TimeSeries::class)->resolveFloorDate($this->projectedModel->updated_at, $period),
+                 ],
+             ])
+             ->first();
     }
 
     /**
@@ -117,7 +120,7 @@ class Projector
             'projection_name' => $this->projectionName,
             'key' => $this->hasKey() ? $this->key() : null,
             'period' => $period,
-            'start_date' => app(TimeSeries::class)->resolveFloorDate($this->projectedModel->created_at, $period),
+            'start_date' => app(TimeSeries::class)->resolveFloorDate($this->projectedModel->updated_at, $period),
             'content' => $this->mergeProjectedContent((new $this->projectionName())->defaultContent(), $period),
         ]);
     }

--- a/tests/Collections/ProjectionCollectionTest.php
+++ b/tests/Collections/ProjectionCollectionTest.php
@@ -223,7 +223,7 @@ class ProjectionCollectionTest extends TestCase
     /** @test */
     public function it_is_formatted_to_a_time_series()
     {
-        Log::factory()->create(['created_at' => today()]);
+        Log::factory()->create(['created_at' => today(), 'updated_at' => today()]);
 
         /** @var ProjectionCollection $collection */
         $collection = Projection::all();


### PR DESCRIPTION
I ran into a blocking issue where non of the time series were retrieved. It turned out that in the projection name queries the backslashes from the FQCN were interpreted as character escapes. This caused a search for App\Models\Model to become a search for AppModelsModel hence nothing got retrieved.

This patch explicitly tells eloquent to use database resolved parameter bindings. With parameter binding the database will figure out if the value should be escaped or not. The tests are still green with this change.

Probably the reason why the tests were green before had to do with Sqlite not doing character escaping whilst MariaDB/MySQL does.